### PR TITLE
Update MuJoCo to 2.3.5; add Crates.IO publishing on release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
       - name: Install Mujoco
-        run: wget https://github.com/deepmind/mujoco/releases/download/2.3.2/mujoco-2.3.2-linux-x86_64.tar.gz; tar -xf mujoco-2.3.2-linux-x86_64.tar.gz -C ~/.local; mv ~/.local/mujoco-2.3.2/ ~/.local/mujoco; sudo cp ~/.local/mujoco/lib/libmujoco.so /usr/lib/libmujoco.so; sudo cp ~/.local/mujoco/lib/libmujoco.so.2.3.2 /usr/lib/libmujoco.so.2.3.2
+        run: wget https://github.com/deepmind/mujoco/releases/download/2.3.5/mujoco-2.3.5-linux-x86_64.tar.gz; tar -xf mujoco-2.3.5-linux-x86_64.tar.gz -C ~/.local; mv ~/.local/mujoco-2.3.5/ ~/.local/mujoco; sudo cp ~/.local/mujoco/lib/libmujoco.so /usr/lib/libmujoco.so; sudo cp ~/.local/mujoco/lib/libmujoco.so.2.3.5 /usr/lib/libmujoco.so.2.3.5
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
@@ -63,7 +63,7 @@ jobs:
       - name: Install mujoco
         run: |
           $ProgressPreference = "SilentlyContinue"
-          Invoke-WebRequest https://github.com/deepmind/mujoco/releases/download/2.3.2/mujoco-2.3.2-windows-x86_64.zip -OutFile mujoco.zip
+          Invoke-WebRequest https://github.com/deepmind/mujoco/releases/download/2.3.5/mujoco-2.3.5-windows-x86_64.zip -OutFile mujoco.zip
           7z x -y mujoco.zip -o"C:\Program Files\MuJoCo" | Out-Null
           del mujoco.zip
       - name: Build and Test
@@ -97,7 +97,7 @@ jobs:
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev
       - name: Install Mujoco
-        run: wget https://github.com/deepmind/mujoco/releases/download/2.3.2/mujoco-2.3.2-linux-x86_64.tar.gz; tar -xf mujoco-2.3.2-linux-x86_64.tar.gz -C ~/.local; mv ~/.local/mujoco-2.3.2/ ~/.local/mujoco; sudo cp ~/.local/mujoco/lib/libmujoco.so /usr/lib/libmujoco.so; sudo cp ~/.local/mujoco/lib/libmujoco.so.2.3.2 /usr/lib/libmujoco.so.2.3.2
+        run: wget https://github.com/deepmind/mujoco/releases/download/2.3.5/mujoco-2.3.5-linux-x86_64.tar.gz; tar -xf mujoco-2.3.5-linux-x86_64.tar.gz -C ~/.local; mv ~/.local/mujoco-2.3.5/ ~/.local/mujoco; sudo cp ~/.local/mujoco/lib/libmujoco.so /usr/lib/libmujoco.so; sudo cp ~/.local/mujoco/lib/libmujoco.so.2.3.5 /usr/lib/libmujoco.so.2.3.5
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1,0 +1,23 @@
+name: PublishCratesIo
+
+on:
+  release:
+    types: [published]
+    
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+          toolchain: stable
+          override: true
+    - uses: katyo/publish-crates@v2
+      with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ These wrappers use `mujoco-rs-sys` to provide rust bindings to the MuJoCo C API.
 
 ```toml
 [dependencies]
-mujoco-rust = { version = "0.0.4" }
+mujoco-rust = { version = "0.0.6" }
 ```
 
 **main.rs**

--- a/mujoco-sys/Cargo.toml
+++ b/mujoco-sys/Cargo.toml
@@ -24,9 +24,9 @@ default = ["mj-render"]
 mj-render = []
 
 [build-dependencies]
-bindgen = "0.63.0"
-dirs = "4.0"
+bindgen = "~0.65.0"
+dirs = "~5.0.0"
 
 [dev-dependencies]
-dirs = "4.0"
+dirs = "~5.0.0"
 lazy_static = "1.4.0"

--- a/mujoco/Cargo.toml
+++ b/mujoco/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mujoco-rust"
-version = "0.0.5"
+version = "0.0.6"
 authors = [
     "Ryan Butler <thebutlah@gmail.com>",
     "Aaron Law <aaronlaw1215@gmail.com>",
@@ -24,8 +24,8 @@ mj-render = ["mujoco-rs-sys/mj-render"]
 
 [dependencies]
 mujoco-rs-sys = { version = "0.0.4", path = "../mujoco-sys", default-features = false }
-dirs = "4.0"
+dirs = "~5.0.0"
 lazy_static = "1.4.0"
 arrayvec = "0.7.2"
 itertools = "0.10.5"
-nalgebra = "0.31.4"
+nalgebra = "0.32.0"


### PR DESCRIPTION
This PR includes updates MuJoCo to the most recent version and introduces Crates.IO publishing for GH releases. You would need to add to generate a cargo API key and CARGO_REGISTRY_TOKEN to repository secrets.